### PR TITLE
Fix glib 42 version errors

### DIFF
--- a/src/chromoview.h
+++ b/src/chromoview.h
@@ -32,7 +32,11 @@ class ChromoTreeClrec: public Gtk::TreeModelColumnRecord
 };
 
 // Chromo tree model
+#if GLIB_CHECK_VERSION(2, 42, 0)
+class ChromoTreeMdl: public Gtk::TreeModel, public Gtk::TreeDragSource, public Glib::Object
+#else
 class ChromoTreeMdl: public Glib::Object, public Gtk::TreeModel, public Gtk::TreeDragSource
+#endif
 {
     public:
 	static Glib::RefPtr<ChromoTreeMdl> create(MElem* aRoot, MEnv* aDesEnv);

--- a/src/navi.h
+++ b/src/navi.h
@@ -29,7 +29,11 @@ class NatnTreeClrec: public Gtk::TreeModelColumnRecord
 };
 
 // Native nodes tree model
+#if GLIB_CHECK_VERSION(2, 42, 0)
+class NatnTreeMdl: public Gtk::TreeModel, public Gtk::TreeDragSource, public Glib::Object
+#else
 class NatnTreeMdl: public Glib::Object, public Gtk::TreeModel, public Gtk::TreeDragSource
+#endif
 {
     public:
 	class GlueItem
@@ -123,7 +127,11 @@ class HierTreeClrec: public Gtk::TreeModelColumnRecord
 };
 
 // Current hier tree model
+#if GLIB_CHECK_VERSION(2, 42, 0)
+class HierTreeMdl: public Gtk::TreeModel, public Gtk::TreeDragSource, public Glib::Object/*, public MCompsObserver*/
+#else
 class HierTreeMdl: public Glib::Object, public Gtk::TreeModel, public Gtk::TreeDragSource/*, public MCompsObserver*/
+#endif
 {
     public:
 	static Glib::RefPtr<HierTreeMdl> create(MEnv* aDesEnv);
@@ -225,7 +233,11 @@ class ModulesTreeClrec: public Gtk::TreeModelColumnRecord
 };
 
 // Modules tree model
+#if GLIB_CHECK_VERSION(2, 42, 0)
+class ModulesTreeMdl: public Gtk::TreeModel, public Gtk::TreeDragSource, public Glib::Object
+#else
 class ModulesTreeMdl: public Glib::Object, public Gtk::TreeModel, public Gtk::TreeDragSource
+#endif
 {
     public:
 	static Glib::RefPtr<ModulesTreeMdl> create(MEnv* aDesEnv);


### PR DESCRIPTION
Fix:
1. GLib-GObject-WARNING *_: attempting to add an interface (GtkTreeModel)
to class ... after class_init
2. GLib-GObject-WARNING *_: attempting to add an interface
(GtkTreeDragSource) to class ... after class_init
